### PR TITLE
Create simple multi-page HTML site

### DIFF
--- a/background.html
+++ b/background.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI工具醫學研究論文搜尋比較分析</title>
+    <title>研究背景</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 2em; }
         nav ul { list-style: none; padding: 0; display: flex; gap: 1em; }
@@ -13,12 +13,12 @@
 <body>
     <nav>
         <ul>
-            <li><a href="background.html">研究背景</a></li>
+            <li><a href="index.html">首頁</a></li>
             <li><a href="tools-analysis.html">AI工具概覽與互動式比較分析</a></li>
             <li><a href="recommendations.html">使用推薦與最佳實踐建議</a></li>
         </ul>
     </nav>
-    <h1>AI工具醫學研究論文搜尋比較分析</h1>
-    <p>請選擇上方頁籤以瀏覽不同內容。</p>
+    <h1>研究背景</h1>
+    <p>本頁面說明進行AI工具醫學研究論文搜尋與比較分析的背景。</p>
 </body>
 </html>

--- a/recommendations.html
+++ b/recommendations.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI工具醫學研究論文搜尋比較分析</title>
+    <title>使用推薦與最佳實踐建議</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 2em; }
         nav ul { list-style: none; padding: 0; display: flex; gap: 1em; }
@@ -13,12 +13,12 @@
 <body>
     <nav>
         <ul>
+            <li><a href="index.html">首頁</a></li>
             <li><a href="background.html">研究背景</a></li>
             <li><a href="tools-analysis.html">AI工具概覽與互動式比較分析</a></li>
-            <li><a href="recommendations.html">使用推薦與最佳實踐建議</a></li>
         </ul>
     </nav>
-    <h1>AI工具醫學研究論文搜尋比較分析</h1>
-    <p>請選擇上方頁籤以瀏覽不同內容。</p>
+    <h1>使用推薦與最佳實踐建議</h1>
+    <p>依據研究需求選擇合適的AI工具，並遵守資料安全與倫理規範。</p>
 </body>
 </html>

--- a/tools-analysis.html
+++ b/tools-analysis.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI工具概覽與互動式比較分析</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        nav ul { list-style: none; padding: 0; display: flex; gap: 1em; }
+        nav a { text-decoration: none; color: #0366d6; }
+        table { border-collapse: collapse; width: 100%; margin-top: 1em; }
+        th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
+        th { cursor: pointer; background-color: #f0f0f0; }
+    </style>
+    <script>
+        function sortTable(n) {
+            const table = document.getElementById("toolTable");
+            let switching = true, dir = "asc";
+            while (switching) {
+                switching = false;
+                const rows = table.rows;
+                for (let i = 1; i < rows.length - 1; i++) {
+                    let shouldSwitch = false;
+                    let x = rows[i].getElementsByTagName("TD")[n];
+                    let y = rows[i + 1].getElementsByTagName("TD")[n];
+                    if (dir === "asc" ? x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase() : x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
+                        shouldSwitch = true;
+                        break;
+                    }
+                }
+                if (shouldSwitch) {
+                    rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+                    switching = true;
+                } else if (!switching && dir === "asc") {
+                    dir = "desc";
+                    switching = true;
+                }
+            }
+        }
+    </script>
+</head>
+<body>
+    <nav>
+        <ul>
+            <li><a href="index.html">首頁</a></li>
+            <li><a href="background.html">研究背景</a></li>
+            <li><a href="recommendations.html">使用推薦與最佳實踐建議</a></li>
+        </ul>
+    </nav>
+    <h1>AI工具概覽與互動式比較分析</h1>
+    <p>點擊表頭可依欄位排序工具資訊。</p>
+    <table id="toolTable">
+        <thead>
+            <tr>
+                <th onclick="sortTable(0)">工具名稱</th>
+                <th onclick="sortTable(1)">特色</th>
+                <th onclick="sortTable(2)">適用情境</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Tool A</td>
+                <td>快速文獻檢索</td>
+                <td>臨床研究</td>
+            </tr>
+            <tr>
+                <td>Tool B</td>
+                <td>自動摘要產生</td>
+                <td>論文撰寫</td>
+            </tr>
+            <tr>
+                <td>Tool C</td>
+                <td>資料可視化</td>
+                <td>成果展示</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the site as plain HTML
- split content into separate pages for research background, tool overview with interactive comparison, and usage recommendations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f38bbee348326800886fa448f052c